### PR TITLE
introduce tooltips to badge config

### DIFF
--- a/libs/storybook-addon-badges/README.md
+++ b/libs/storybook-addon-badges/README.md
@@ -44,12 +44,36 @@ addParameters({
     beta: {
       contrast: '#FFF',
       color: '#018786',
-      title: 'Beta'
+      title: 'Beta',
+      tooltip: 'Be ready to receive updates frequently.'
     },
     deprecated: {
       contrast: '#FFF',
       color: '#6200EE',
       title: 'Deprecated'
+    }
+  }
+});
+```
+
+Optionally, you can define more complex tooltips for any of your badges.
+
+```js
+addParameters({
+  badgesConfig: {
+    beta: {
+      ...betaConfig,
+      tooltip: {
+        title: 'This is Beta',
+        desc: 'Be ready to receive updates frequently and leave a feedback',
+        links: [
+          {title: 'Read more', href: 'http://path/to/your/docs'},
+          {title: 'Leave feedback', onClick: () => {alert('thanks for the feedback')}}]
+      }
+    },
+    deprecated: {
+      ...deprecatedConfig,
+      tooltip: 'This component is depricated, pleave avoid using it.'
     }
   }
 });

--- a/libs/storybook-addon-badges/src/lib/blocks/badge.tsx
+++ b/libs/storybook-addon-badges/src/lib/blocks/badge.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
-import type { BadgeConfig } from '../types';
+import { WithBadgeTooltip } from './withBadgeTooltip';
+import type { BadgeProps } from '../types';
 import { getColor, getContrastColor, getTitle } from '../helpers/helpers';
-import { styled } from '@storybook/theming'
-
+import { styled } from '@storybook/theming';
 
 export const BadgeWrapper = styled.span`
   align-items: center;
@@ -11,11 +11,6 @@ export const BadgeWrapper = styled.span`
   height: 100%;
   user-select: none;
 `;
-
-interface BadgeProps {
-  badge: string;
-  config: BadgeConfig,
-}
 
 export const BadgeInner = styled.span<BadgeProps>`
   border: 1px solid ${({ badge, config }) => getColor(badge, config)};
@@ -28,11 +23,12 @@ export const BadgeInner = styled.span<BadgeProps>`
   text-transform: uppercase;
 `;
 
+const BadgeInnerWithTooltip = WithBadgeTooltip(BadgeInner);
+
 export const Badge: FC<BadgeProps> = ({ badge, config }) => (
   <BadgeWrapper>
-    <BadgeInner badge={badge} config={config}>
+    <BadgeInnerWithTooltip badge={badge} config={config}>
       {getTitle(badge, config)}
-    </BadgeInner>
+    </BadgeInnerWithTooltip>
   </BadgeWrapper>
 );
-

--- a/libs/storybook-addon-badges/src/lib/blocks/withBadgeTooltip.tsx
+++ b/libs/storybook-addon-badges/src/lib/blocks/withBadgeTooltip.tsx
@@ -1,0 +1,26 @@
+import React, { FC, ComponentType } from 'react';
+import { WithTooltip, TooltipMessage } from '@storybook/components';
+
+import type { BadgeProps } from '../types';
+import { getTooltip } from '../helpers/helpers';
+
+export const WithBadgeTooltip =
+  <T extends BadgeProps = BadgeProps>(Component: ComponentType<T>): FC<T> =>
+  ({ badge, config, ...rest }) => {
+    const tooltipData = getTooltip(badge, config);
+
+    let tooltipMessageProps: typeof tooltipData;
+    if (typeof tooltipData === 'string') {
+      tooltipMessageProps = { desc: tooltipData };
+    } else {
+      tooltipMessageProps = tooltipData;
+    }
+
+    return tooltipData ? (
+      <WithTooltip tooltip={<TooltipMessage {...tooltipMessageProps} />}>
+        <Component badge={badge} config={config} {...(rest as T)} />
+      </WithTooltip>
+    ) : (
+      <Component badge={badge} config={config} {...(rest as T)} />
+    );
+  };

--- a/libs/storybook-addon-badges/src/lib/helpers/helpers.ts
+++ b/libs/storybook-addon-badges/src/lib/helpers/helpers.ts
@@ -1,21 +1,23 @@
-import { BadgeConfig } from '../types';
+import { BadgeConfig, TooltipConfig } from '../types';
 import { defaultBadgeConfig } from '../shared';
 
-export const getBadgeConfig =
-  (badge: string, config: BadgeConfig): BadgeConfig => ({
-    ...defaultBadgeConfig,
-    title: badge,
-    ...config,
-  });
+export const getBadgeConfig = (
+  badge: string,
+  config: BadgeConfig
+): BadgeConfig => ({
+  ...defaultBadgeConfig,
+  title: badge,
+  ...config,
+});
 
-export const getColor =
-  (badge: string, config: BadgeConfig): string =>
-    getBadgeConfig(badge, config).color;
+export const getColor = (badge: string, config: BadgeConfig): string =>
+  getBadgeConfig(badge, config).color;
 
-export const getContrastColor =
-  (badge: string, config: BadgeConfig): string =>
-    getBadgeConfig(badge, config).contrast;
+export const getContrastColor = (badge: string, config: BadgeConfig): string =>
+  getBadgeConfig(badge, config).contrast;
 
-export const getTitle =
-  (badge: string, config: BadgeConfig): string =>
-    getBadgeConfig(badge, config).title;
+export const getTitle = (badge: string, config: BadgeConfig): string =>
+  getBadgeConfig(badge, config).title;
+
+export const getTooltip = (badge: string, config: BadgeConfig): TooltipConfig =>
+  getBadgeConfig(badge, config).tooltip;

--- a/libs/storybook-addon-badges/src/lib/types.ts
+++ b/libs/storybook-addon-badges/src/lib/types.ts
@@ -1,10 +1,22 @@
+import { ComponentProps } from 'react';
+import { TooltipMessage } from '@storybook/components';
+
+export type TooltipConfig =
+  | Omit<ComponentProps<typeof TooltipMessage>, 'children'>
+  | string;
+
 export type BadgeConfig = {
   title?: string;
   color?: string;
   contrast?: string;
-}
+  tooltip?: TooltipConfig;
+};
 
 export interface BadgesConfig {
-  [id: string]: BadgeConfig,
+  [id: string]: BadgeConfig;
 }
 
+export interface BadgeProps {
+  badge: string;
+  config: BadgeConfig;
+}


### PR DESCRIPTION
Hi, thanks a lot for your work.
Please consider this PR as a feature request, so feel free to just close it if you don't like it. No question will be asked from my side.

--- 

![image](https://user-images.githubusercontent.com/1269797/133909657-ec427949-f062-4ad9-9db9-44b835f7cbbe.png)
![image](https://user-images.githubusercontent.com/1269797/133909664-12f3825f-eada-42a6-8323-acb421ad63c3.png)

tooltip can be a `string` or an object of type
```
{
  title: string,
  desc: string,
  links: { title: string, href: string, onClick: () => void }
}
```

Tooltip API is the same as @storybook/components TooltipMessage component.


